### PR TITLE
Removed duplicated json data.

### DIFF
--- a/spec/common-self-hosting-auth-sections.json
+++ b/spec/common-self-hosting-auth-sections.json
@@ -128,12 +128,6 @@
         "slug": "verifies-a-sign-up",
         "title": "Verifies a sign up",
         "type": "operation"
-      },
-      {
-        "id": "verifies-a-sign-up",
-        "slug": "verifies-a-sign-up",
-        "title": "Verifies a sign up",
-        "type": "operation"
       }
     ]
   }


### PR DESCRIPTION
There was a duplicated json object for verified-a-sign-up field. So, I removed it. It was making the same button appear twice on the website.